### PR TITLE
Updates to support more leagues, time.sleep(6), and started_match info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 web_pages/
 __pycache__/
-test.db
-test.py
+master.db

--- a/db_helper.json
+++ b/db_helper.json
@@ -22,6 +22,7 @@
       "player_id": "char(8) NOT NULL",
       "name": "varchar",
       "home_away": "char(1)",
+      "started_match": "int",
       "squad_number": "int",
       "nation": "varchar",
       "position": "varchar",

--- a/db_helper.json
+++ b/db_helper.json
@@ -198,6 +198,12 @@
     "Bundesliga": 20,
     "La_Liga": 12,
     "Ligue_1": 13,
-    "Serie_A": 11
+    "Serie_A": 11,
+    "Championship": 10,
+    "Eredivisie": 23,
+    "Primeira_Liga": 32,
+    "Belgian_Pro_League": 37,
+    "Argentine_Copa_de_la_Liga": 21,
+    "Brazilian_Serie_A": 24
   }
 }

--- a/main.py
+++ b/main.py
@@ -31,7 +31,17 @@ def main(database_file, competitions=["Premier_League"], seasons=["2021-2022"]):
 
 
 if __name__ == "__main__":
-    competitions = ["Premier_League", "Bundesliga", "La_Liga", "Ligue_1", "Serie_A"]
+    competitions = [
+        "Premier_League",
+        # "Bundesliga",
+        # "La_Liga",
+        # "Ligue_1",
+        # "Serie_A",
+        # "Primeira_Liga",
+        # "Championship",
+        # "Eredivisie",
+        # "Belgian_Pro_League",
+    ]
     seasons = [
         # "2017-2018",
         # "2018-2019",
@@ -43,3 +53,15 @@ if __name__ == "__main__":
         "2024-2025",
     ]
     main("master.db", competitions=competitions, seasons=seasons)
+
+    special_comps = [
+        # "Argentine_Copa_de_la_Liga",
+        # "Brazilian_Serie_A",
+    ]
+    special_seasons = [
+        # "2021",
+        # "2022",
+        # "2023",
+        # "2024",
+    ]
+    main("master.db", competitions=special_comps, seasons=special_seasons)

--- a/matches.py
+++ b/matches.py
@@ -5,6 +5,8 @@ from bs4 import BeautifulSoup
 
 from utils import insert
 
+import time
+
 
 def get_match_data(competition, season):
     # Note that matches where the full match data is not yet available will still be picked up here and inserted
@@ -16,6 +18,7 @@ def get_match_data(competition, season):
         url = f"https://fbref.com/en/comps/{competition_id}/{season}/schedule/"
 
     with requests.Session() as s:
+        time.sleep(6)
         table = BeautifulSoup(s.get(url).text, "lxml").find("table")
         rows = table.find_all("tr")
 
@@ -48,6 +51,8 @@ def get_match_data(competition, season):
 
 
 def update_matches(cursor, competition, season):
-    cursor.execute("DELETE FROM Match WHERE competition = ? AND season = ?", (competition, season))
+    cursor.execute(
+        "DELETE FROM Match WHERE competition = ? AND season = ?", (competition, season)
+    )
     match_data = get_match_data(competition, season)
     insert(cursor, "Match", match_data)

--- a/players.py
+++ b/players.py
@@ -21,8 +21,12 @@ def get_player_info(match_id, tables):
             player_id = row.find("th").find("a")["href"].split("/")[3]
             player_name = row.find("a").text
             home_away = "H" if table_num < 10 else "A"
+            started_match = 1 if row.text[0].isalpha() else 0
             rest_of_row = clean_row([x.text for x in row.find_all("td")][:5])
-            data.append([match_id, player_id, player_name, home_away] + rest_of_row)
+            data.append(
+                [match_id, player_id, player_name, home_away, started_match]
+                + rest_of_row
+            )
     return data
 
 

--- a/update_local.py
+++ b/update_local.py
@@ -41,13 +41,72 @@ def update_local(competition, season):
 
     serie_a_relegation = {"e0449015"}
 
+    primeira_liga_relegation = {"c8cd6748", "65aab877", "fb49ed3b", "b4f01c0d"}
+
+    championship_relegation = {
+        "bffb3b8a",  # 2021-2022
+        "8d994b81",
+        "4216543d",
+        "0b847a0a",
+        "6b6beef8",
+        "cc45efca",  # 2022-2023
+        "f06587a0",
+        "1a587649",
+        "f41aa3c8",
+        "78ccd86d",
+        "4ca40ec1",  # 2023-2024
+        "882e5566",
+        "3d1b21b1",
+        "b1047caa",
+        "75957831",
+    }
+
+    eredivisie_relegation = {
+        "a672f305",  # 2022-2023
+        "09128e80",
+        "7c8dd541",
+        "c0a0e179",
+        "9fd3030e",
+        "0fff319f",
+        "26d8f7f2",
+        "3cf91762",
+        "f2cf0bb2",
+        "08d6ee8e",
+        "96853577",
+        "a2c1e2d6",
+    }
+
+    belgian_pro_league_relegation = {
+        "2446aa1b",  # 2021-2022
+        "b9de2b9d",
+        "53a3e9a1",  # 2023-2024
+        "8b4f3bc8",
+        "923b19a0",
+        "2a8c63ff",
+        "4f453cc2",
+        "cf18476c",
+        "ff05bbbc",
+        "a2c6c9e8",
+        "b5b0e366",
+        "7fc3135c",
+        "41b7a481",
+        "90ca2b04",
+    }
+
     other_ignore = {
         "e0a20cfe",  # SerieA_2020-2021 - Verona:Roma - Result Awarded - Registration Error
         "c34bbc21",  # Bundesliga_2021-2022 - Bochum:Monchengladbach - Abandoned - Fan Trouble
     }
 
     ignored_matches = (
-        bundesliga_relegation | ligue1_relegation | serie_a_relegation | other_ignore
+        bundesliga_relegation
+        | ligue1_relegation
+        | serie_a_relegation
+        | primeira_liga_relegation
+        | championship_relegation
+        | eredivisie_relegation
+        | belgian_pro_league_relegation
+        | other_ignore
     )
 
     if not os.path.exists("web_pages"):


### PR DESCRIPTION
Added more matches to ignore from other leagues in the update_local.py file. Added master.db to the .gitignore so that it is not included in any commits. Added time.sleep(6) to the scraping function to not get banned. Added more leagues to main.py and their competition ids in db_helper.json. Added the started_match column in the player_info scrape function and also in the db_helper for player_info table